### PR TITLE
feat: Create landing page and add RWD

### DIFF
--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -1,0 +1,19 @@
+import React from "react";
+import Button from "../resuableComponents/Button";
+
+
+function LandingPage() {
+    return (
+        <div className="mx-auto flex flex-col justify-start space-y-48 bg-[url('./assets/images/chessboardBg.png')] w-full h-screen bg-cover bg-no-repeat bg-center">
+            <div className="mx-auto flex flex-col items-center justify-center">
+                <h1 className="text-zinc-100 text-4xl font-roboto font-extrabold mt-28 sm:text-5xl lg:text-7xl ">MASTER GAME</h1>
+            </div>
+            <div className="mx-auto flex flex-col items-center">
+                <Button buttontext="PLAY" />
+                <Button buttontext="RULES" />
+            </div>
+        </div>
+    );
+}
+
+export default LandingPage;


### PR DESCRIPTION
# Description 

Created LandingPage folder and `LandingPage` component. The landing page has a background image of a chessboard, a h1 element with the value "Master Chess" and a "PLAY" button and a "RULES" button. The `Button` component was created in the reusableComponents folder. No functionality has been added to the buttons yet.

# Testing Instruction 

1. Run `npm start`
2. Visit `http://localhost:3000/`

# Screenshots

## Desktop

<img width="1504" alt="chessboardDesktop" src="https://user-images.githubusercontent.com/104450960/199361556-e61d0d61-3df7-4f23-90aa-366e99c0311e.png">

## Tablet

<img width="711" alt="chessboardTablet" src="https://user-images.githubusercontent.com/104450960/199361894-e8800282-6050-40ae-9953-619ec8e50e24.png">

## Mobile

<img width="514" alt="chessboardMobile" src="https://user-images.githubusercontent.com/104450960/199361928-90dc27de-dece-422c-b576-bd0a9208ea4d.png">
